### PR TITLE
Added 'updateUser' and made 'find' User compatible

### DIFF
--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -25,15 +25,71 @@ Parse.prototype = {
   // get objects from class store
   find: function (className, query, callback) {
     if (typeof query === 'string') {
-      parseRequest.call(this, 'GET', '/1/classes/' + className + '/' + query, null, callback);
+
+      // adding special case for Parse's User class
+      if(className !== 'User' && className !== 'users') {
+        parseRequest.call(this, 'GET', '/1/classes/' + className + '/' + query, null, callback);
+      } else {
+        parseRequest.call(this, 'GET', '/1/users/' + query, null, callback);
+      }
+
     } else {
-      parseRequest.call(this, 'GET', '/1/classes/' + className, { where: JSON.stringify(query) }, callback);
+
+      // adding special case for Parse's User class
+      if(className !== 'User' && className !== 'users') {
+        parseRequest.call(this, 'GET', '/1/classes/' + className, { where: JSON.stringify(query) }, callback);
+      } else {
+        parseRequest.call(this, 'GET', '/1/users/', { where: JSON.stringify(query) }, callback);
+      }
+      
     }
   },
 
   // update an object in the class store
   update: function (className, objectId, object, callback) {
     parseRequest.call(this, 'PUT', '/1/classes/' + className + '/' + objectId, object, callback);
+  },
+
+  // update a single user - supports queries or objectId. Safely provides error where queries have more than one result instead of updating all.
+  updateUser: function (userQuery, object, callback) {
+    var objectId;
+    
+    // check if a query was passed in instead of objectId
+    if(typeof userQuery === 'string') {
+      
+      // user objectId was passed
+      objectId = userQuery;
+
+    } else {
+      
+      // get the user objectId 
+      this.find('User', userQuery, function(err, response) {
+        
+        if(err === null) {
+          
+          // response will be {"results":[]} if there is an error
+          if(response.results.length === 1) {
+            
+            // just get the first result, assuming 
+            objectId = response.results[0].objectId;
+
+          } else if(response.results.length > 1) {
+            return callback({ status: "failed", message: 'There was more than one result for your query, so an update was deemed too dangerous to perform.'}, response);
+          } else {
+            return callback({ status: "failed", message: 'There were no results for your query.'}, response);
+          };
+
+        } else {
+
+          // there was an error finding the User
+          return callback(err, response);
+        };
+
+      });
+    };
+
+    parseRequest.call(this, 'PUT', '/1/users/' + objectId, object, callback);
+
   },
 
   // remove an object from the class store

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -52,31 +52,39 @@ Parse.prototype = {
 
   // update a single user - supports queries or objectId. Safely provides error where queries have more than one result instead of updating all.
   updateUser: function (userQuery, object, callback) {
-    var objectId;
-    
+    var objectId = null;
+    var that = this;
+
     // check if a query was passed in instead of objectId
     if(typeof userQuery === 'string') {
       
       // user objectId was passed
       objectId = userQuery;
+      parseRequest.call(that, 'PUT', '/1/users/' + objectId, object, callback);
 
     } else {
       
       // get the user objectId 
       this.find('User', userQuery, function(err, response) {
-        
+
         if(err === null) {
           
           // response will be {"results":[]} if there is an error
           if(response.results.length === 1) {
-            
+
             // just get the first result, assuming 
             objectId = response.results[0].objectId;
+            console.dir(objectId);
+            parseRequest.call(that, 'PUT', '/1/users/' + objectId, object, callback);
 
           } else if(response.results.length > 1) {
-            return callback({ status: "failed", message: 'There was more than one result for your query, so an update was deemed too dangerous to perform.'}, response);
+            console.dir('error 1');
+            console.dir(response);
+            // return callback({ status: "error", message: 'There was more than one result for your query, so an update was deemed too dangerous to perform.'}, response);
           } else {
-            return callback({ status: "failed", message: 'There were no results for your query.'}, response);
+            console.dir('error 2');
+            console.dir(response);
+            // return callback({ status: "error", message: 'There were no results for your query.'}, response);
           };
 
         } else {
@@ -87,9 +95,6 @@ Parse.prototype = {
 
       });
     };
-
-    parseRequest.call(this, 'PUT', '/1/users/' + objectId, object, callback);
-
   },
 
   // remove an object from the class store
@@ -135,6 +140,7 @@ function parseRequest(method, path, data, callback, contentType) {
   };
 
   var req = this._api_protocol.request(options, function (res) {
+
     if (!callback) {
       return;
     }
@@ -164,6 +170,7 @@ function parseRequest(method, path, data, callback, contentType) {
         // pass to callback
       }
       callback(err, data);
+      console.dir('sent data to callback');
     });
 
     res.on('close', function (err) {

--- a/lib/Parse.js
+++ b/lib/Parse.js
@@ -78,13 +78,9 @@ Parse.prototype = {
             parseRequest.call(that, 'PUT', '/1/users/' + objectId, object, callback);
 
           } else if(response.results.length > 1) {
-            console.dir('error 1');
-            console.dir(response);
-            // return callback({ status: "error", message: 'There was more than one result for your query, so an update was deemed too dangerous to perform.'}, response);
+            return callback({ status: "error", message: 'There was more than one result for your query, so an update was deemed too dangerous to perform.'}, response);
           } else {
-            console.dir('error 2');
-            console.dir(response);
-            // return callback({ status: "error", message: 'There were no results for your query.'}, response);
+            return callback({ status: "error", message: 'There were no results for your query.'}, response);
           };
 
         } else {


### PR DESCRIPTION
As the title suggests, I found myself always needing to get a user's objectId by providing some sort of query, then using the objectId to perform a user update. This function does both in one shot and supports user queries as well as user objectIds.

To do this i had to improve the find function to handle User objects, which have a different Parse API path to normal objects.
